### PR TITLE
Add Docker image build check for pull requests

### DIFF
--- a/.github/workflows/portainer-deploy.yml
+++ b/.github/workflows/portainer-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - master
+  pull_request:
+    branches:
+      - '**'
   workflow_dispatch: {}
 
 env:
@@ -13,7 +16,24 @@ env:
   TAG: latest
 
 jobs:
+  pr-docker-build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
   build-and-deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- trigger the existing workflow on pull_request events
- add a PR-only job that builds the Docker image without pushing
- keep the deploy flow limited to non-PR events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1a50b22c83308e5249f6d1ba1fcb)