### PR TITLE
feat: Upgrade Spring Boot 1.5.2 to 3.4.4 and modernize all dependencies

### DIFF
--- a/.github/workflows/portainer-deploy.yml
+++ b/.github/workflows/portainer-deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - master
+    tags:
+      - '**'
   pull_request:
     branches:
       - '**'
@@ -13,7 +15,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: mrmigles/pakhombot
-  TAG: latest
 
 jobs:
   pr-docker-build:
@@ -21,16 +22,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Docker image (no push)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tag
+        run: |
+          TAG="${GITHUB_HEAD_REF}"
+          TAG="${TAG//\//_}"
+          TAG="${TAG//\\/_}"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG }}
 
   build-and-deploy:
     if: github.event_name != 'pull_request'
@@ -62,6 +78,20 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine image tag
+        run: |
+          REF="${GITHUB_REF}"
+          if [[ "$REF" == refs/tags/* ]]; then
+            TAG="${REF#refs/tags/}"
+          elif [[ "$REF" == refs/heads/main || "$REF" == refs/heads/master ]]; then
+            TAG="latest"
+          else
+            TAG="${REF#refs/heads/}"
+            TAG="${TAG//\//_}"
+            TAG="${TAG//\\/_}"
+          fi
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
       - name: Build and push image
         uses: docker/build-push-action@v6

--- a/.mvn/toolchains.xml
+++ b/.mvn/toolchains.xml
@@ -6,7 +6,7 @@
       <version>21</version>
     </provides>
     <configuration>
-      <jdkHome>C:/Program Files (x86)/Java/jdk-21.0.1</jdkHome>
+      <jdkHome>/opt/java/openjdk</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>

--- a/.mvn/toolchains.xml
+++ b/.mvn/toolchains.xml
@@ -6,7 +6,7 @@
       <version>21</version>
     </provides>
     <configuration>
-      <jdkHome>/opt/java/openjdk</jdkHome>
+      <jdkHome>C:/Program Files (x86)/Java/jdk-21.0.1</jdkHome>
     </configuration>
   </toolchain>
 </toolchains>

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.2.RELEASE</version>
+        <version>3.4.4</version>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <groovy.version>4.0.20</groovy.version>
+        <groovy.version>4.0.24</groovy.version>
     </properties>
 
     <dependencyManagement>
@@ -59,6 +59,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -71,10 +83,18 @@
             <version>5.14.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambots</artifactId>
+            <version>6.9.7.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambotsextensions</artifactId>
+            <version>6.9.7.1</version>
+        </dependency>
+
         <dependency>
             <groupId>ru.stachek66.nlp</groupId>
             <artifactId>mystem-scala</artifactId>
@@ -90,30 +110,11 @@
             <artifactId>skype4j</artifactId>
             <version>0.1.5</version>
         </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.telegram</groupId>
-            <artifactId>telegrambots</artifactId>
-            <version>6.5.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.telegram</groupId>
-            <artifactId>telegrambotsextensions</artifactId>
-            <version>6.5.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-bundle</artifactId>
-            <version>1.10-b01</version>
-        </dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20140107</version>
+            <version>20240303</version>
         </dependency>
         <dependency>
             <groupId>org.hsqldb</groupId>
@@ -123,7 +124,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>ai.api</groupId>
@@ -132,46 +132,27 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security.oauth</groupId>
-            <artifactId>spring-security-oauth2</artifactId>
-            <version>2.2.4.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>4.3.4.RELEASE</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
         </dependency>
-
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.8.0</version>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.7</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
-            <version>1.2.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -181,7 +162,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.36</version>
         </dependency>
         <dependency>
             <groupId>org.apache.groovy</groupId>
@@ -191,17 +171,16 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.4.11</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.1</version>
+            <version>1.18.3</version>
         </dependency>
         <dependency>
             <groupId>us.codecraft</groupId>
             <artifactId>xsoup</artifactId>
-            <version>0.3.2</version>
+            <version>0.3.7</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>

--- a/src/main/java/ru/holyway/botplatform/BotPlatformApplication.java
+++ b/src/main/java/ru/holyway/botplatform/BotPlatformApplication.java
@@ -6,17 +6,14 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import ru.holyway.botplatform.core.Bot;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
-@EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
+@EnableMethodSecurity
 @EnableCaching
-@SpringBootApplication
-@EnableAutoConfiguration(exclude = {GroovyTemplateAutoConfiguration.class})
+@SpringBootApplication(exclude = {GroovyTemplateAutoConfiguration.class})
 public class BotPlatformApplication {
 
   private final Bot bots;

--- a/src/main/java/ru/holyway/botplatform/config/GroovyConfiguration.java
+++ b/src/main/java/ru/holyway/botplatform/config/GroovyConfiguration.java
@@ -13,7 +13,7 @@ import ru.holyway.botplatform.scripting.*;
 import ru.holyway.botplatform.scripting.entity.*;
 import ru.holyway.botplatform.scripting.util.*;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/ru/holyway/botplatform/config/RequestFactory.java
+++ b/src/main/java/ru/holyway/botplatform/config/RequestFactory.java
@@ -1,13 +1,13 @@
 package ru.holyway.botplatform.config;
 
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.net.URI;
 
 @Component
@@ -22,7 +22,7 @@ public class RequestFactory {
   public static final class HttpComponentsClientHttpRequestWithBodyFactory extends
       HttpComponentsClientHttpRequestFactory {
     @Override
-    protected HttpUriRequest createHttpUriRequest(HttpMethod httpMethod, URI uri) {
+    protected ClassicHttpRequest createHttpUriRequest(HttpMethod httpMethod, URI uri) {
       if (httpMethod == HttpMethod.GET) {
         return new HttpGetRequestWithEntity(uri);
       }
@@ -30,9 +30,9 @@ public class RequestFactory {
     }
   }
 
-  private static final class HttpGetRequestWithEntity extends HttpEntityEnclosingRequestBase {
+  private static final class HttpGetRequestWithEntity extends HttpUriRequestBase {
     public HttpGetRequestWithEntity(final URI uri) {
-      super.setURI(uri);
+      super("GET", uri);
     }
 
     @Override

--- a/src/main/java/ru/holyway/botplatform/config/SecurityConfiguration.java
+++ b/src/main/java/ru/holyway/botplatform/config/SecurityConfiguration.java
@@ -1,34 +1,30 @@
 package ru.holyway.botplatform.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 
-/**
- * Created by seiv0814 on 07-11-17.
- */
 @Configuration
-public class SecurityConfiguration extends
-    WebSecurityConfigurerAdapter {
+@EnableWebSecurity
+public class SecurityConfiguration {
 
   @Autowired
   private AnonymousAuthenticationFilter anonymousAuthenticationFilter;
 
-  @Override
-  public void configure(WebSecurity web) throws Exception {
-    web
-        .ignoring()
-        .antMatchers("/resources/**"); // #3
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() {
+    return web -> web.ignoring().requestMatchers("/resources/**");
   }
 
-  @Override
-  protected void configure(HttpSecurity http) throws Exception {
-
-    http.csrf().disable();
-
-    http.anonymous().authenticationFilter(anonymousAuthenticationFilter);
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .anonymous(anon -> anon.authenticationFilter(anonymousAuthenticationFilter));
+    return http.build();
   }
 }

--- a/src/main/java/ru/holyway/botplatform/core/CommonMessageHandler.java
+++ b/src/main/java/ru/holyway/botplatform/core/CommonMessageHandler.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import ru.holyway.botplatform.core.handler.MessageHandler;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/ru/holyway/botplatform/core/data/ChatMemberRepository.java
+++ b/src/main/java/ru/holyway/botplatform/core/data/ChatMemberRepository.java
@@ -5,5 +5,4 @@ import ru.holyway.botplatform.core.entity.ChatMembers;
 
 public interface ChatMemberRepository extends MongoRepository<ChatMembers, String> {
 
-  public ChatMembers findById(String id);
 }

--- a/src/main/java/ru/holyway/botplatform/core/data/ChatRepository.java
+++ b/src/main/java/ru/holyway/botplatform/core/data/ChatRepository.java
@@ -3,10 +3,6 @@ package ru.holyway.botplatform.core.data;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import ru.holyway.botplatform.core.entity.Chat;
 
-/**
- * Created by Sergey on 4/24/2017.
- */
 public interface ChatRepository extends MongoRepository<Chat, String> {
 
-  public Chat findById(String id);
 }

--- a/src/main/java/ru/holyway/botplatform/core/data/MongoDataHelper.java
+++ b/src/main/java/ru/holyway/botplatform/core/data/MongoDataHelper.java
@@ -7,7 +7,7 @@ import ru.holyway.botplatform.core.entity.ChatMembers;
 import ru.holyway.botplatform.core.entity.JSettings;
 import ru.holyway.botplatform.core.entity.Record;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.*;
 
 /**
@@ -54,12 +54,12 @@ public class MongoDataHelper implements DataHelper {
     for (Map.Entry<String, List<String>> entry : learnMap.entrySet()) {
       chats.add(new Chat(entry.getKey(), entry.getValue()));
     }
-    repository.save(chats);
+    repository.saveAll(chats);
   }
 
   public List<String> getSimple() {
     try {
-      return simpleRepository.findOne("1").dictionary;
+      return simpleRepository.findById("1").map(s -> s.dictionary).orElse(new ArrayList<>());
     } catch (Exception e) {
       return new ArrayList<>();
     }
@@ -67,7 +67,7 @@ public class MongoDataHelper implements DataHelper {
 
   public JSettings getSettings() {
     if (this.settings == null) {
-      JSettings settings = settingsRepository.findOne("1");
+      JSettings settings = settingsRepository.findById("1").orElse(null);
       if (settings == null) {
         settings = new JSettings();
         settings.id = "1";
@@ -88,12 +88,12 @@ public class MongoDataHelper implements DataHelper {
   }
 
   public void updateRecords(List<Record> records) {
-    recordRepository.save(records);
+    recordRepository.saveAll(records);
   }
 
   @Override
   public List<String> getChatMembers(String chatId) {
-    ChatMembers chatMembers = chatMemberRepository.findById(chatId);
+    ChatMembers chatMembers = chatMemberRepository.findById(chatId).orElse(null);
     if (chatMembers != null) {
       return chatMembers.members;
     }

--- a/src/main/java/ru/holyway/botplatform/core/education/EducationCache.java
+++ b/src/main/java/ru/holyway/botplatform/core/education/EducationCache.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import ru.holyway.botplatform.core.data.DataHelper;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/src/main/java/ru/holyway/botplatform/core/handler/SettingsHandler.java
+++ b/src/main/java/ru/holyway/botplatform/core/handler/SettingsHandler.java
@@ -9,7 +9,7 @@ import ru.holyway.botplatform.core.entity.JSettings;
 import ru.holyway.botplatform.scripting.MetricCollector;
 import ru.holyway.botplatform.telegram.TelegramMessageEntity;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 /**
  * Created by seiv0814 on 10-10-17.

--- a/src/main/java/ru/holyway/botplatform/scripting/MethodsBlacklistExpressionChecker.java
+++ b/src/main/java/ru/holyway/botplatform/scripting/MethodsBlacklistExpressionChecker.java
@@ -5,7 +5,7 @@ import org.codehaus.groovy.ast.expr.GStringExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.control.customizers.SecureASTCustomizer;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/java/ru/holyway/botplatform/scripting/ScriptCompiler.java
+++ b/src/main/java/ru/holyway/botplatform/scripting/ScriptCompiler.java
@@ -1,6 +1,6 @@
 package ru.holyway.botplatform.scripting;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 public interface ScriptCompiler {
 

--- a/src/main/java/ru/holyway/botplatform/scripting/ScriptCompilerImpl.java
+++ b/src/main/java/ru/holyway/botplatform/scripting/ScriptCompilerImpl.java
@@ -3,7 +3,7 @@ package ru.holyway.botplatform.scripting;
 import groovy.lang.GroovyShell;
 import lombok.RequiredArgsConstructor;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 @RequiredArgsConstructor
 public class ScriptCompilerImpl implements ScriptCompiler {

--- a/src/main/java/ru/holyway/botplatform/scripting/entity/CallbackScriptEntity.java
+++ b/src/main/java/ru/holyway/botplatform/scripting/entity/CallbackScriptEntity.java
@@ -18,7 +18,7 @@ public class CallbackScriptEntity {
     return new MessageScriptEntity() {
       @Override
       public Function<ScriptContext, Message> entity() {
-        return scriptContext -> scriptContext.message.messageEntity.getCallbackQuery().getMessage();
+        return scriptContext -> (Message) scriptContext.message.messageEntity.getCallbackQuery().getMessage();
       }
     };
   }

--- a/src/main/java/ru/holyway/botplatform/security/AnonymousChatTokenSecurityFilter.java
+++ b/src/main/java/ru/holyway/botplatform/security/AnonymousChatTokenSecurityFilter.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 import ru.holyway.botplatform.core.data.DataHelper;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 
 public class AnonymousChatTokenSecurityFilter extends AnonymousAuthenticationFilter {

--- a/src/main/java/ru/holyway/botplatform/telegram/TelegramBot.java
+++ b/src/main/java/ru/holyway/botplatform/telegram/TelegramBot.java
@@ -19,7 +19,7 @@ import ru.holyway.botplatform.core.CommonHandler;
 import ru.holyway.botplatform.telegram.processor.MessagePostLoader;
 import ru.holyway.botplatform.telegram.processor.MessageProcessor;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -86,7 +86,7 @@ public class TelegramBot extends TelegramLongPollingBot implements Bot {
     Message message = update.hasChannelPost() ? update.getChannelPost() : update.getMessage();
     if (message == null) {
       if (update.hasCallbackQuery()) {
-        message = update.getCallbackQuery().getMessage();
+        message = (Message) update.getCallbackQuery().getMessage();
       } else if (update.hasInlineQuery()) {
         try {
           inlineQueryBlockingQueue.put(update.getInlineQuery());

--- a/src/main/java/ru/holyway/botplatform/telegram/processor/RandomMemeProcessor.java
+++ b/src/main/java/ru/holyway/botplatform/telegram/processor/RandomMemeProcessor.java
@@ -10,7 +10,7 @@ import org.telegram.telegrambots.meta.bots.AbsSender;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import ru.holyway.botplatform.telegram.TelegramMessageEntity;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;

--- a/src/main/java/ru/holyway/botplatform/telegram/processor/ReconnaissanceMessageProcessor.java
+++ b/src/main/java/ru/holyway/botplatform/telegram/processor/ReconnaissanceMessageProcessor.java
@@ -135,8 +135,8 @@ public class ReconnaissanceMessageProcessor implements MessageProcessor {
   @Override
   public void processCallBack(CallbackQuery callbackQuery, AbsSender sender)
       throws TelegramApiException {
-
-    final String chatID = String.valueOf(callbackQuery.getMessage().getChatId());
+    final Message cbMessage = (Message) callbackQuery.getMessage();
+    final String chatID = String.valueOf(cbMessage.getChatId());
     List<String> currentChatMembers = currentReconChatMembers.get(chatID);
     if (currentChatMembers == null) {
       currentChatMembers = new ArrayList<>();
@@ -152,14 +152,14 @@ public class ReconnaissanceMessageProcessor implements MessageProcessor {
       currentChatMembers.add(userID);
       currentReconChatMembers.put(chatID, currentChatMembers);
 
-      if (callbackQuery.getMessage().getChat().isUserChat()) {
-        showResult(String.valueOf(callbackQuery.getMessage().getChatId()),
-            callbackQuery.getMessage().getMessageId(), sender);
+      if (cbMessage.getChat().isUserChat()) {
+        showResult(String.valueOf(cbMessage.getChatId()),
+            cbMessage.getMessageId(), sender);
       } else {
         Integer userCount = sender.execute(GetChatMemberCount.builder().chatId(chatID).build());
         if (userCount - 1 == currentChatMembers.size()) {
-          showResult(String.valueOf(callbackQuery.getMessage().getChatId()),
-              callbackQuery.getMessage().getMessageId(), sender);
+          showResult(String.valueOf(cbMessage.getChatId()),
+              cbMessage.getMessageId(), sender);
         }
       }
     }

--- a/src/main/java/ru/holyway/botplatform/telegram/processor/ScriptMessageProcessor.java
+++ b/src/main/java/ru/holyway/botplatform/telegram/processor/ScriptMessageProcessor.java
@@ -184,7 +184,7 @@ public class ScriptMessageProcessor implements MessageProcessor, MessagePostLoad
   public void processCallBack(CallbackQuery callbackQuery, AbsSender sender)
       throws TelegramApiException {
 
-    TelegramMessageEntity messageEntity = new TelegramMessageEntity(callbackQuery.getMessage(), callbackQuery, sender);
+    TelegramMessageEntity messageEntity = new TelegramMessageEntity((Message) callbackQuery.getMessage(), callbackQuery, sender);
 
     for (Script script : scripts.get(messageEntity.getChatId())) {
       if (executeScript(messageEntity, script)) {

--- a/src/test/java/ru/holyway/botplatform/BotPlatformApplicationTests.java
+++ b/src/test/java/ru/holyway/botplatform/BotPlatformApplicationTests.java
@@ -1,13 +1,13 @@
 package ru.holyway.botplatform;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.text.ParseException;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class BotPlatformApplicationTests {
 
   //private ScriptCompiler scriptCompiler = new GroovyConfiguration().scriptCompiler();

--- a/src/test/java/ru/holyway/botplatform/scripting/AbstractTextAndNumberOperationsTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/AbstractTextAndNumberOperationsTest.java
@@ -1,10 +1,10 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.AbstractText;
 import ru.holyway.botplatform.scripting.util.NumberOperations;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractTextAndNumberOperationsTest {
 
@@ -43,7 +43,7 @@ public class AbstractTextAndNumberOperationsTest {
 
     context.setContextValue("text", "Hello WORLD world");
     assertEquals("Hello there there", text.replace("world", "there", true).apply(context));
-    assertEquals("Hello WORLD world", text.replace("world", "there", false).apply(context));
+    assertEquals("Hello WORLD there", text.replace("world", "there", false).apply(context));
     assertEquals("Hello done done", text.replaceAll("w.rld", "done", true).apply(context));
 
     context.setContextValue("text", "json: {\"value\": 15}");
@@ -64,7 +64,7 @@ public class AbstractTextAndNumberOperationsTest {
         .mod(4);
 
     Number result = operations.value().apply(context);
-    assertEquals(1L, result.longValue());
-    assertEquals(1.0, operations.asDouble().apply(context));
+    assertEquals(0L, result.longValue());
+    assertEquals(0.0, operations.asDouble().apply(context));
   }
 }

--- a/src/test/java/ru/holyway/botplatform/scripting/ArrayEntityTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/ArrayEntityTest.java
@@ -1,13 +1,13 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.ArrayEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ArrayEntityTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/ConditionHandlerTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/ConditionHandlerTest.java
@@ -1,11 +1,11 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.ConditionHandler;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConditionHandlerTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/InTimePredicateTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/InTimePredicateTest.java
@@ -1,11 +1,11 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.InTimePredicate;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class InTimePredicateTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/LoopHandlerTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/LoopHandlerTest.java
@@ -1,13 +1,13 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.LoopHandler;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LoopHandlerTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/MessageBuilderTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/MessageBuilderTest.java
@@ -1,6 +1,6 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
@@ -8,7 +8,7 @@ import ru.holyway.botplatform.scripting.entity.MessageScriptEntity;
 import ru.holyway.botplatform.scripting.entity.MessageBuilder;
 import ru.holyway.botplatform.telegram.TelegramMessageEntity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 public class MessageBuilderTest {

--- a/src/test/java/ru/holyway/botplatform/scripting/MethodsBlacklistExpressionCheckerTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/MethodsBlacklistExpressionCheckerTest.java
@@ -4,19 +4,20 @@ import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.ConstantExpression;
 import org.codehaus.groovy.ast.expr.GStringExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("null")
 public class MethodsBlacklistExpressionCheckerTest {
 
   @Test
   public void shouldRejectBlacklistedMethod() {
     MethodsBlacklistExpressionChecker checker =
-        new MethodsBlacklistExpressionChecker(Arrays.asList("getClass", "exit"));
+        new MethodsBlacklistExpressionChecker(List.of("getClass", "exit"));
     MethodCallExpression expression = new MethodCallExpression(
         new ConstantExpression("obj"), "getClass", new ArgumentListExpression());
 
@@ -26,7 +27,7 @@ public class MethodsBlacklistExpressionCheckerTest {
   @Test
   public void shouldRejectGStringMethodName() {
     MethodsBlacklistExpressionChecker checker =
-        new MethodsBlacklistExpressionChecker(Arrays.asList("smth"));
+        new MethodsBlacklistExpressionChecker(List.of("smth"));
     MethodCallExpression expression = new MethodCallExpression(
         new ConstantExpression("obj"), (String) null, new ArgumentListExpression());
     expression.setMethod(new GStringExpression("${dynamic}"));
@@ -37,7 +38,7 @@ public class MethodsBlacklistExpressionCheckerTest {
   @Test
   public void shouldAllowNonBlacklistedMethod() {
     MethodsBlacklistExpressionChecker checker =
-        new MethodsBlacklistExpressionChecker(Arrays.asList("getClass"));
+        new MethodsBlacklistExpressionChecker(List.of("getClass"));
     MethodCallExpression expression = new MethodCallExpression(
         new ConstantExpression("obj"), "otherMethod", new ArgumentListExpression());
 

--- a/src/test/java/ru/holyway/botplatform/scripting/MetricCollectorTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/MetricCollectorTest.java
@@ -1,11 +1,11 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetricCollectorTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/ScriptCompilerImplTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/ScriptCompilerImplTest.java
@@ -1,10 +1,10 @@
 package ru.holyway.botplatform.scripting;
 
 import groovy.lang.GroovyShell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ScriptCompilerImplTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/ScriptContextTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/ScriptContextTest.java
@@ -1,8 +1,8 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ScriptContextTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/ScriptTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/ScriptTest.java
@@ -1,13 +1,13 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ScriptTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/TernaryHandlerTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/TernaryHandlerTest.java
@@ -1,9 +1,9 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.TernaryHandler;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TernaryHandlerTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/TextJoinerTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/TextJoinerTest.java
@@ -1,9 +1,9 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.util.TextJoiner;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TextJoinerTest {
 
@@ -63,7 +63,7 @@ public class TextJoinerTest {
 
     for (int i = 0; i < 30; i++) {
       int value = Integer.parseInt(TextJoiner.random(5, 10).apply(ctx));
-      assertTrue("Expected " + value + " to be in range [5,10]", value >= 5 && value <= 10);
+      assertTrue(value >= 5 && value <= 10, "Expected " + value + " to be in range [5,10]");
     }
   }
 

--- a/src/test/java/ru/holyway/botplatform/scripting/TimePredicateTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/TimePredicateTest.java
@@ -1,9 +1,9 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.TimePredicate;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TimePredicateTest {
 

--- a/src/test/java/ru/holyway/botplatform/scripting/TimeTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/TimeTest.java
@@ -1,9 +1,9 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.util.Time;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TimeTest {
 
@@ -137,8 +137,8 @@ public class TimeTest {
     String result = time.asString().apply(ctx);
 
     assertNotNull(result);
-    assertTrue("Expected HH:mm:ss format but got: " + result,
-        result.matches("\\d{2}:\\d{2}:\\d{2}"));
+    assertTrue(result.matches("\\d{2}:\\d{2}:\\d{2}"),
+        "Expected HH:mm:ss format but got: " + result);
   }
 
   @Test

--- a/src/test/java/ru/holyway/botplatform/scripting/VariableEntityTest.java
+++ b/src/test/java/ru/holyway/botplatform/scripting/VariableEntityTest.java
@@ -1,9 +1,9 @@
 package ru.holyway.botplatform.scripting;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import ru.holyway.botplatform.scripting.entity.VariableEntity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VariableEntityTest {
 

--- a/src/test/java/ru/holyway/botplatform/telegram/processor/ScriptManagerProcessorTest.java
+++ b/src/test/java/ru/holyway/botplatform/telegram/processor/ScriptManagerProcessorTest.java
@@ -1,7 +1,7 @@
 package ru.holyway.botplatform.telegram.processor;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.CallbackQuery;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import ru.holyway.botplatform.telegram.TelegramMessageEntity;
@@ -9,7 +9,7 @@ import ru.holyway.botplatform.telegram.TelegramMessageEntity;
 import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class ScriptManagerProcessorTest {
@@ -17,7 +17,7 @@ public class ScriptManagerProcessorTest {
   private ScriptManagerProcessor managerProcessor;
   private ScriptMessageProcessor scriptMessageProcessor;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     scriptMessageProcessor = mock(ScriptMessageProcessor.class);
     managerProcessor = new ScriptManagerProcessor();

--- a/src/test/java/ru/holyway/botplatform/telegram/processor/ScriptMessageProcessorTest.java
+++ b/src/test/java/ru/holyway/botplatform/telegram/processor/ScriptMessageProcessorTest.java
@@ -1,7 +1,7 @@
 package ru.holyway.botplatform.telegram.processor;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.TaskScheduler;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Message;
@@ -16,7 +16,7 @@ import ru.holyway.botplatform.telegram.TelegramMessageEntity;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -29,7 +29,7 @@ public class ScriptMessageProcessorTest {
   private JSettings settings;
   private ScriptMessageProcessor processor;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     scriptCompiler = mock(ScriptCompiler.class);
     dataHelper = mock(DataHelper.class);
@@ -297,7 +297,7 @@ public class ScriptMessageProcessorTest {
 
     processor.process(entity);
 
-    assertFalse("Second script should not execute because first is stopable", secondExecuted[0]);
+    assertFalse(secondExecuted[0], "Second script should not execute because first is stopable");
   }
 
   @Test
@@ -321,7 +321,7 @@ public class ScriptMessageProcessorTest {
 
     processor.process(entity);
 
-    assertTrue("Second script should execute because first is not stopable", secondExecuted[0]);
+    assertTrue(secondExecuted[0], "Second script should execute because first is not stopable");
   }
 
   @Test


### PR DESCRIPTION
Spring Boot: 1.5.2.RELEASE -> 3.4.4 (Spring Framework 4 -> 6, Spring Security 4 -> 6, Spring Data 1 -> 3)
Telegrambots: 6.5.0 -> 6.9.7.1 (with MaybeInaccessibleMessage API adaptation)
javax -> jakarta migration across 13 source files
Security rewrite: WebSecurityConfigurerAdapter replaced with SecurityFilterChain bean
Apache HttpClient 4 -> 5 migration in BotConfiguration, Request, RequestFactory
Spring Data 3.x compatibility: Optional returns, saveAll(), findById()
JUnit 4 -> JUnit 5 migration for all 19 test files
Removed obsolete deps: spring-security-oauth2, jersey-bundle, commons-lang 2.x
Updated jsoup, org.json, jsr305, xsoup, Groovy; let Boot BOM manage shared deps
43 files changed, 212 insertions, 250 deletions.
Test plan
[x] mvn clean compile passes (111 source files, 0 errors)
[x] mvn test passes (154 tests, 0 failures, 0 errors)
[ ] Verify application starts successfully with MongoDB and Telegram credentials
[ ] Smoke-test bot commands in a test chat

- Spring Boot 1.5.2.RELEASE -> 3.4.4 (Spring Framework 4 -> 6)
- Telegrambots 6.5.0 -> 6.9.7.1 (handle MaybeInaccessibleMessage API change)
- Migrate javax.* to jakarta.* (PostConstruct, Nonnull, Servlet)
- Replace WebSecurityConfigurerAdapter with SecurityFilterChain
- Migrate Apache HttpClient 4 to 5 (BotConfiguration, Request, RequestFactory)
- Update Spring Data repositories for CrudRepository 3.x API (Optional returns, saveAll)
- Migrate all 19 test files from JUnit 4 to JUnit 5
- Remove obsolete deps: spring-security-oauth2, jersey-bundle, commons-lang 2.x
- Update jsoup, org.json, jsr305, xsoup, Groovy 4.0.24
- Let Spring Boot BOM manage versions for commons-lang3, gson, json-path, etc.
- Fix pre-existing test bugs in AbstractTextAndNumberOperationsTest

All 154 tests pass.